### PR TITLE
Fix SSH reliability and TUI crash on disconnect

### DIFF
--- a/lib/verb_nodes.py
+++ b/lib/verb_nodes.py
@@ -35,9 +35,14 @@ if cmd not in ['create', 'info']:
       # ssh command
       if cmd == 'ssh':
         subprocess.run([
-          'ssh', '-l', cloudinituser, vmip(vmid),
+          'ssh',
+          '-l', cloudinituser, vmip(vmid),
+          '-t',                                   # force TTY allocation
           '-o', 'StrictHostKeyChecking=no',
-        ])
+          '-o', 'ServerAliveInterval=15',         # detect dead connections
+          '-o', 'ServerAliveCountMax=3',
+          '-o', 'ExitOnForwardFailure=yes',
+        ], env={**os.environ, 'TERM': os.environ.get('TERM', 'xterm-256color')})
         exit(0)
 
       # destroy vm


### PR DESCRIPTION
- verb_nodes.py: add -t (force TTY), ServerAliveInterval/CountMax and explicit TERM passthrough to ssh so arrow keys and ctrl sequences work correctly inside the session
- devbox_tui.py: wrap _run_interactive in try/except so terminal is always restored cleanly after an abrupt SSH disconnect, and log the session exit code back in the TUI
- devbox_tui.py: ignore SIGHUP at startup so the TUI survives losing the outer SSH connection rather than crashing

https://claude.ai/code/session_01Nu6eoHasGmwP5rNwM6BeEB